### PR TITLE
Replace hub with gh command tool

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -74,4 +74,4 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
           tag_name: ${{ env.release_tag }}
         run: |
-          hub release edit $(find . -type f -name "*.sif" -printf "-a %p ") -m "" "$tag_name" 
+          gh release upload "$tag_name" $(find . -type f -name "*.sif" -printf "%p ")


### PR DESCRIPTION
As per this announcement: https://github.com/actions/runner-images/issues/8362 `hub` command is no longer included in the hosted runners. 
This change allows artifact upload to keep running using `gh` tool.